### PR TITLE
proxy.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The Nginx configuration in this image is based on the guidelines given by the [W
 * `POST_MAX_SIZE`: Sets max size of post data allowed. Also affects file uploads (defaults to `64m`).
 * `BEHIND_PROXY`: Set to `true` if this container is behind a reverse proxy (defaults to `false` unless `VIRTUAL_HOST` environment variable is set).
 * `REAL_IP_HEADER`: Defines the request header that will be used to obtain the real client IP when `BEHIND_PROXY` is set to `true` (defaults to `X-Forwarded-For`).
-* `REAL_IP_FROM`: Defines trusted addresses to obtain the real client IP when `BEHIND_PROXY` is set to `true` (defaults to `172.17.0.0/16`).
+* `REAL_IP_FROM`: Defines trusted addresses to obtain the real client IP when `BEHIND_PROXY` is set to `true` (defaults to `172.16.0.0/12`).
+* `WP_CONTAINER_NAME`: Defines your Wordpress (PHP-FPM) container's name aka fastcgi_pass (defaults to `wordpress`).
 
 ### ... via [`docker-compose`](https://github.com/docker/compose)
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,12 +27,14 @@ if [ "$1" == nginx ]; then
     : "${BEHIND_PROXY:=$([ -z ${VIRTUAL_HOST} ] && echo "false" || echo "true")}"
     : "${REAL_IP_HEADER:=X-Forwarded-For}"
     : "${REAL_IP_FROM:=172.17.0.0/16}"
-
+	: "${WP_CONTAINER_NAME:=wordpress}"
+	
     common_post_max_size
 
     sed -i 's/client_max_body_size *[0-9]\+[kKmM]\?/client_max_body_size '"${POST_MAX_SIZE}"'/' /etc/nginx/conf.d/default.conf
     sed -i 's/upload_max_filesize *= *[0-9]\+[kKmMgG]\?/upload_max_filesize='"${POST_MAX_SIZE}"'/' /etc/nginx/global/wordpress.conf
     sed -i 's/post_max_size *= *[0-9]\+[kKmMgG]\?/post_max_size='"${POST_MAX_SIZE}"'/' /etc/nginx/global/wordpress.conf
+    sed -i 's/fastcgi_pass .*;/fastcgi_pass '"$(escape_sed "${WP_CONTAINER_NAME}")"':9000;/' /etc/nginx/global/wordpress.conf
 
     if [ "${BEHIND_PROXY}" == "true" ]; then
         sed -i 's/real_ip_header .*;/real_ip_header '"$(escape_sed "${REAL_IP_HEADER}")"';/' /etc/nginx/global/proxy.conf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,8 +27,8 @@ if [ "$1" == nginx ]; then
     : "${BEHIND_PROXY:=$([ -z ${VIRTUAL_HOST} ] && echo "false" || echo "true")}"
     : "${REAL_IP_HEADER:=X-Forwarded-For}"
     : "${REAL_IP_FROM:=172.17.0.0/16}"
-	: "${WP_CONTAINER_NAME:=wordpress}"
-	
+    : "${WP_CONTAINER_NAME:=wordpress}"
+
     common_post_max_size
 
     sed -i 's/client_max_body_size *[0-9]\+[kKmM]\?/client_max_body_size '"${POST_MAX_SIZE}"'/' /etc/nginx/conf.d/default.conf

--- a/proxy.conf
+++ b/proxy.conf
@@ -1,2 +1,3 @@
 real_ip_header X-Forwarded-For;
-set_real_ip_from 172.17.0.0/16;
+set_real_ip_from 172.16.0.0/12;
+real_ip_recursive on;


### PR DESCRIPTION
1) Extend private IP range to standard: https://en.wikipedia.org/wiki/Private_network
2) Add "real_ip_recursive on" to fix 2 or more reverse proxy layers (nginx, varnish, web server, for example): https://serverfault.com/questions/314574/nginx-real-ip-header-and-x-forwarded-for-seems-wrong